### PR TITLE
0.5b Vertical layout fixes

### DIFF
--- a/assets/css/onScreenKeyboard.css
+++ b/assets/css/onScreenKeyboard.css
@@ -96,15 +96,15 @@
 /*-----[Customisable styles]--------------------------------------------------*/
 
 #osk-container {
-	width: 86%;     /* Account for 2% padding and a vertical scroll bar */
-       left: 7% !important;
-	min-width: 500px;
+	width: 96%;     /* Account for 2% padding */
+       left: 2% !important;
+	min-width: 300px;
 	max-width: 1200px;
 	background: #2B3C4E;
        color: #fff;
 	border-radius: 5%;
 	box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
-       font-size: 22px;
+       font-size: 1em;
 }
 
 #osk-container > li {

--- a/assets/css/runeui.css
+++ b/assets/css/runeui.css
@@ -5,6 +5,7 @@ html {
     -ms-text-size-adjust: 100%;
     -webkit-text-size-adjust: 100%
 }
+html::-webkit-scrollbar { width: 0 !important }
 body {
     margin: 0
 }

--- a/assets/js/vendor/jquery.onScreenKeyboard.js
+++ b/assets/js/vendor/jquery.onScreenKeyboard.js
@@ -294,8 +294,8 @@
 					'<span class="osk-off">=</span>' +
 					'<span class="osk-on">+</span>' +
 				'</li>' +
-				'<li class="osk-backspace osk-last-item">backspace</li>' +
-				'<li class="osk-tab">tab</li>' +
+				'<li class="osk-backspace osk-last-item">←</li>' +
+				'<li class="osk-tab">⇆</li>' +
 				'<li class="osk-letter">q</li>' +
 				'<li class="osk-letter">w</li>' +
 				'<li class="osk-letter">e</li>' +
@@ -318,7 +318,7 @@
 					'<span class="osk-off">\\</span>' +
 					'<span class="osk-on">|</span>' +
 				'</li>' +
-				'<li class="osk-capslock">caps lock</li>' +
+				'<li class="osk-capslock">🅰</li>' +
 				'<li class="osk-letter">a</li>' +
 				'<li class="osk-letter">s</li>' +
 				'<li class="osk-letter">d</li>' +
@@ -336,8 +336,8 @@
 					'<span class="osk-off">\'</span>' +
 					'<span class="osk-on">@</span>' +
 				'</li>' +
-				'<li class="osk-return osk-last-item">return</li>' +
-				'<li class="osk-shift">shift</li>' +
+				'<li class="osk-return osk-last-item">⮠</li>' +
+				'<li class="osk-shift">⇑</li>' +
 				'<li class="osk-letter">z</li>' +
 				'<li class="osk-letter">x</li>' +
 				'<li class="osk-letter">c</li>' +


### PR DESCRIPTION
Hi,
I've noticed two annoyances in portrait mode:

* The vertical scrollbar takes valuable space (and is useless as we can touch-scroll)
* The keyboard was too wide to be fully displayed (and the Hide key was off-screen)

These patches fix both issues, and also replaces text with symbols on symbol keys (backspace, tab, enter, etc.)

Hope this helps!