### PR TITLE
Lyrics: fail if HTTP status code isn't 200

### DIFF
--- a/command/lyric.sh
+++ b/command/lyric.sh
@@ -9,4 +9,4 @@ title=`perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "$title"`
 echo $artist
 echo $title
 
-curl -s "https://makeitpersonal.co/lyrics?artist=$artist&title=$title" |sed ':a;N;$!ba;s/\n/<\/br>/g'
+curl -sf "https://makeitpersonal.co/lyrics?artist=$artist&title=$title" |sed ':a;N;$!ba;s/\n/<\/br>/g'


### PR DESCRIPTION
Hi,

My own fix for the lyrics server failure: make curl fail instead of outputting the error page.
Allows keeping command/lyric.sh executable.