### PR TITLE
Disable pinch and other extra features we don't want in kiosk mode

### DIFF
--- a/app/config/_os/etc/X11/xinit/start_chromium.sh
+++ b/app/config/_os/etc/X11/xinit/start_chromium.sh
@@ -5,4 +5,4 @@ CHROMIUM_TEMP=/tmp/chromium
 sudo http mkdir -p $CHROMIUM_TEMP
 export HOME=$CHROMIUM_TEMP
 
-chromium --app=http://localhost --start-fullscreen --force-device-scale-factor=1.8
+chromium --app=http://localhost --start-fullscreen --force-device-scale-factor=1.8 --kiosk --disable-pinch --disable-translate --disable-crash-reporter --disable-infobars --check-for-update-interval=8640000

--- a/app/config/defaults/start_chromium.sh
+++ b/app/config/defaults/start_chromium.sh
@@ -5,4 +5,4 @@ CHROMIUM_TEMP=/tmp/chromium
 sudo http mkdir -p $CHROMIUM_TEMP
 export HOME=$CHROMIUM_TEMP
 
-chromium --app=http://localhost --start-fullscreen --force-device-scale-factor=1.8
+chromium --app=http://localhost --start-fullscreen --force-device-scale-factor=1.8 --kiosk --disable-pinch --disable-translate --disable-crash-reporter --disable-infobars --check-for-update-interval=8640000

--- a/app/libs/runeaudio.php
+++ b/app/libs/runeaudio.php
@@ -1392,6 +1392,7 @@ function wrk_xorgconfig($redis, $action, $args)
 			$file = '/etc/X11/xinit/start_chromium.sh';
 			// replace the line with 'force-device-scale-factor='
 			$newArray = wrk_replaceTextLine($file, '', 'force-device-scale-factor', 'chromium --app=http://localhost --start-fullscreen --force-device-scale-factor='.$args);
+			$newArray = wrk_replaceTextLine($file, '', 'force-device-scale-factor', 'chromium --app=http://localhost --start-fullscreen --force-device-scale-factor='.$args.' --kiosk --disable-pinch --disable-translate --disable-crash-reporter --disable-infobars --check-for-update-interval=8640000');
 			// Commit changes to /etc/X11/xinit/start_chromium.sh
 			$fp = fopen($file, 'w');
 			$return = fwrite($fp, implode("", $newArray));

--- a/command/update_os.php
+++ b/command/update_os.php
@@ -142,7 +142,7 @@ function updateOS($redis) {
 				$redis->del('local_browser');
 				$redis->hSet('local_browser', 'enable', $local_browser);
 				if (file_exists('/usr/bin/xinit')) {
-					$zoomfactor = sysCmd("grep -i 'force-device-scale-factor=' /etc/X11/xinit/start_chromium.sh | cut -d'=' -f3");
+					$zoomfactor = sysCmd("grep -i 'force-device-scale-factor=' /etc/X11/xinit/start_chromium.sh | cut -d'=' -f3 | cut -d' ' -f1");
 					$redis->hSet('local_browser', 'zoomfactor', $zoomfactor[0]);
 					unset($zoomfactor);
 				}


### PR DESCRIPTION
This avoids having pinch gestures messing up the screen, translation, crash report, infobars and automatic update check.